### PR TITLE
Prohibit cursor zoom while cursor is unlocked

### DIFF
--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -16,7 +16,7 @@ impl Plugin for MousePlugin {
             Update,
             (
                 orbit_mouse.run_if(orbit_condition),
-                zoom_mouse.run_if(zoom_condition),
+                zoom_mouse.run_if(zoom_condition && orbit_condition),
             )
                 .chain(),
         );


### PR DESCRIPTION
Prohibit zoom in/out while cursor is not orbiting. For use when interacting with menus, etc.