### PR TITLE
Prohibit zoom changes while scrolling in menus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ fn aim(
 
 pub fn zoom_condition(cam_q: Query<&ThirdPersonCamera, With<ThirdPersonCamera>>) -> bool {
     let Ok(cam) = cam_q.get_single() else { return false };
-    cam.zoom_enabled
+    return cam.zoom_enabled && cam.cursor_lock_active;
 }
 
 // only run toggle_x_offset if `offset_toggle_enabled` is true

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -16,7 +16,7 @@ impl Plugin for MousePlugin {
             Update,
             (
                 orbit_mouse.run_if(orbit_condition),
-                zoom_mouse.run_if(zoom_condition && orbit_condition),
+                zoom_mouse.run_if(zoom_condition),
             )
                 .chain(),
         );

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -16,7 +16,7 @@ impl Plugin for MousePlugin {
             Update,
             (
                 orbit_mouse.run_if(orbit_condition),
-                zoom_mouse.run_if(zoom_condition),
+                zoom_mouse.run_if(zoom_condition && orbit_condition),
             )
                 .chain(),
         );


### PR DESCRIPTION
Changes the zoom_condition function so it checks both zoom_enabled AND cursor_lock_active.

This fixes the issue in my other pull request (that I didn't test... whoops!) where Bevy's `run_if` function only accepts functions that return booleans, rather than the booleans themselves.