### PR TITLE
move the full future version of bevy into dev-dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,6 @@ exclude = ["assets/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.12.0"
+bevy = { version = "0.12.0", default-features = false }
+[dev-dependencies]
+bevy = { version = "0.12.0" }


### PR DESCRIPTION
include the full feature in the dependency will make all crates that depends on this crate to use all features.